### PR TITLE
fix: cancel and submit removed from footer in pay now modal

### DIFF
--- a/finalize.html
+++ b/finalize.html
@@ -816,7 +816,7 @@
                        </span>
                        <div>
                            <span class="d-block text-dark text-opacity-50 fs-9 text-uppercase">billing</span>
-                           <h3 class="fs-3 m-0 mt-2">Complete Subscription Renewal</h3>
+                           <h3 class="fs-3 m-0 mt-2">Complete Onboarding Process</h3>
                        </div>
                    </div>
 
@@ -857,7 +857,7 @@
                </div>
 
                <!-- Modal Body Ends-->
-               <div class="modal-footer">
+               <!-- <div class="modal-footer">
                    <div class="d-flex justify-content-end align-items-center w-100">
                        <button type="button"
                            class="btn btn-link text-decoration-none font-weight-600 payment-close-btn">
@@ -866,7 +866,7 @@
                        <button type="button" class="btn btn-secondary px-4 text-decoration-none font-weight-600 pay-now-btn"
                            data-bs-dismiss="modal">Submit</button>
                    </div>
-               </div>
+               </div> -->
 
            </div>
        </div>


### PR DESCRIPTION
fix: cancel and submit removed from footer in pay now modal